### PR TITLE
changed UUID handling for delete and execute

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -48,10 +48,10 @@ func ExecuteCommand(cmd *cobra.Command, args []string, wg *sync.WaitGroup, resul
 		}
 		err = json.Unmarshal(jsonData, &wl)
 		if wl.GetRunId() == "" {
-			wl.RunID = utils.GenerateUUID()
+			wl.RunID = wl.Name + "_" +  utils.GenerateRandNum()
 		}
 		if wl.GetUUID() == "" {
-			wl.UUID = utils.GenerateUUID()
+			wl.UUID = wl.Name + "_" +  utils.GenerateRandNum()
 		}
 		if err != nil {
 			fmt.Println("Error parsing workload JSON:", err)
@@ -166,11 +166,13 @@ func DeleteCommand(cmd *cobra.Command, args []string, wg *sync.WaitGroup, result
 			os.Exit(1)
 		}
 		err = json.Unmarshal(jsonData, &wl)
-		if wl.GetRunId() == "" {
-			wl.RunID = utils.GenerateUUID()
-		}
-		if wl.GetUUID() == "" {
-			wl.UUID = utils.GenerateUUID()
+		if wl.UUID == "" {
+			if workload.GetWorkloadUUIDByName(configManager, wl.Name) != "" {
+				wl.UUID = workload.GetWorkloadUUIDByName(configManager, wl.Name)
+			} else {
+				fmt.Println("No workload with this name exists!")
+				os.Exit(1)
+			}
 		}
 		if err != nil {
 			fmt.Println("Error parsing workload JSON:", err)
@@ -179,11 +181,13 @@ func DeleteCommand(cmd *cobra.Command, args []string, wg *sync.WaitGroup, result
 	} else if len(args) == 1 {
 		// Parse the JSON workload from the command line argument
 		err = json.Unmarshal([]byte(args[0]), &wl)
-		if wl.GetRunId() == "" {
-			wl.RunID = utils.GenerateUUID()
-		}
-		if wl.GetUUID() == "" {
-			wl.UUID = utils.GenerateUUID()
+		if wl.UUID == "" {
+			if workload.GetWorkloadUUIDByName(configManager, wl.Name) != "" {
+				wl.UUID = workload.GetWorkloadUUIDByName(configManager, wl.Name)
+			} else {
+				fmt.Println("No workload with this name exists!")
+				os.Exit(1)
+			}
 		}
 		if err != nil {
 			fmt.Println("Error parsing workload JSON:", err)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,11 +1,13 @@
 package utils
 
 import (
-	"cloudblockscli.com/internal/config"
-	"crypto/rand"
-	"fmt"
-	// "github.com/joho/godotenv"
-	"os"
+    "cloudblockscli.com/internal/config"
+    cryptoRand "crypto/rand"
+    mathRand "math/rand"
+    "strconv"
+    "time"
+    "fmt"
+    "os"
 )
 
 // func LoadEnv(configManager config.ConfigManager) error {
@@ -17,13 +19,30 @@ import (
 // }
 
 func GenerateUUID() string {
-	b := make([]byte, 16)
-	_, err := rand.Read(b)
-	if err != nil {
-		return ""
-	}
-	uuid := fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
-	return uuid
+    b := make([]byte, 16)
+    _, err := cryptoRand.Read(b)
+    if err != nil {
+        return ""
+    }
+    uuid := fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+    return uuid
+}
+
+func GenerateRandNum() string {
+    mathRand.Seed(time.Now().UnixNano())
+
+    // Generate a random number between 0 and 999
+    randomNum := mathRand.Intn(1000)
+
+    // Convert the random number to a string
+    randomNumStr := strconv.Itoa(randomNum)
+
+    // Pad the string with leading zeros if necessary
+    for len(randomNumStr) < 3 {
+        randomNumStr = "0" + randomNumStr
+    }
+
+    return randomNumStr
 }
 
 func CheckModulesDirectory(configManager config.ConfigManager) bool {
@@ -52,7 +71,6 @@ func DeleteWorkDir(configManager config.ConfigManager, name string) error {
 	}
 	return nil
 }
-
 func CreateWorkDir(configManager config.ConfigManager, name string) error {
 	if CheckWorkDir(configManager, name) {
 		return fmt.Errorf("directory already exists")


### PR DESCRIPTION
Changed handling of UUID and RunID. If the user doesn't provide a UUID, the program will try to find a workload by name and use the UUID from that. If that doesn't exist, it will throw an error and exit. Auto-generated UUIDs and RunIDs use the workload name + a short random number for readability. Delete now uses just the name to find a UUID 